### PR TITLE
LoadCode loading incorrect amount of characters from ini

### DIFF
--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -430,7 +430,7 @@ namespace Memory
             uint read_ini_result;
 
             if (file != "")
-                read_ini_result = GetPrivateProfileString("codes", name, "", returnCode, (uint)file.Length, file);
+                read_ini_result = GetPrivateProfileString("codes", name, "", returnCode, (uint)returnCode.Capacity, file);
             else
                 returnCode.Append(name);
 


### PR DESCRIPTION
LoadCode was loading the incorrect number of characters from the ini file.  It was loading based on the file path length rather then the capacity of the StringBuilder instance.