### PR TITLE
Fixed arithmetic overflow in AoB Scan

### DIFF
--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -1842,9 +1842,6 @@ namespace Memory
 
             for (int index = start; index <= body.Length - pattern.Length; index++)
             {
-                if (index == 0x154620)
-                    index = 0x154620;
-
                 if (((body[index] & masks[0]) == (pattern[0] & masks[0])))
                 {
                     var match = true;

--- a/Memory/MemoryRegionResult.cs
+++ b/Memory/MemoryRegionResult.cs
@@ -8,9 +8,9 @@ namespace Memory
 {
     struct MemoryRegionResult
     {
-        public IntPtr CurrentBaseAddress { get; set; }
+        public UIntPtr CurrentBaseAddress { get; set; }
         public long RegionSize { get; set; }
-        public IntPtr RegionBase { get; set; }
+        public UIntPtr RegionBase { get; set; }
 
     }
 }


### PR DESCRIPTION
The arithmetic overflow in AoB scan was fixed by changing most the code to use UIntPtr instead of UIntPtr code needs tested fully before merging