### PR TITLE
unnecessary use of Regex import ,fixing ReadString & Optional '?' instead of '??' in AoB Scan

### DIFF
--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -568,12 +568,12 @@ namespace Memory
         /// Read a string value from an address.
         /// </summary>
         /// <param name="code">address, module + pointer + offset, module + offset OR label in .ini file.</param>
+	/// <param name="file">path and name of ini file. (OPTIONAL)</param>  
 	/// <param name="length">length of bytes to read (OPTIONAL)</param>
-        /// <param name="encoding">the encoding that will be used for GetString.</param>
         /// <param name="zeroTerminated">determines if the string will be splited at null char.</param>
-        /// <param name="file">path and name of ini file. (OPTIONAL)</param>        
+	/// <param name="encoding">the encoding that will be used for GetString.</param>
         /// <returns></returns>
-        public string readString(string code, int length = 255, bool zeroTerminated = false, Encoding encoding = null, string file = "")
+        public string readString(string code, string file = "", int length = 32, bool zeroTerminated = false, Encoding encoding = null)
         {
             if (encoding == null)
                 encoding = Encoding.Default;

--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -1674,7 +1674,7 @@ namespace Memory
             {
                 string ba = stringByteArray[i];
 
-                if (ba == "??")
+                if (ba == "??" || ba.Length == 1 && ba == "?")
                 {
                     mask[i] = 0x00;
                     stringByteArray[i] = "0x00";

--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -576,7 +576,7 @@ namespace Memory
         public string readString(string code, string file = "", int length = 32, bool zeroTerminated = false, Encoding encoding = null)
         {
             if (encoding == null)
-                encoding = Encoding.Default;
+                encoding = Encoding.UTF8;
             byte[] memoryNormal = new byte[length];
             UIntPtr theCode;
             theCode = getCode(code, file);

--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -571,13 +571,13 @@ namespace Memory
         /// <param name="file">path and name of ini file. (OPTIONAL)</param>
         /// <param name="length">length of bytes to read (OPTIONAL)</param>
         /// <returns></returns>
-        public string readString(string code, string file = "", int length = 32)
+        public string readString(string code, string file = "", int length = 255)
         {
             byte[] memoryNormal = new byte[length];
             UIntPtr theCode;
             theCode = getCode(code, file);
             if (ReadProcessMemory(pHandle, theCode, memoryNormal, (UIntPtr)length, IntPtr.Zero))
-                return Encoding.UTF8.GetString(memoryNormal);
+                return Encoding.UTF8.GetString(memoryNormal).Split('\0')[0];
             else
                 return "";
         }

--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -568,16 +568,20 @@ namespace Memory
         /// Read a string value from an address.
         /// </summary>
         /// <param name="code">address, module + pointer + offset, module + offset OR label in .ini file.</param>
+        /// <param name="encoding">the encoding that will be used for GetString.</param>
+        /// <param name="zeroTerminated">determines if the string will be splited at null char.</param>
         /// <param name="file">path and name of ini file. (OPTIONAL)</param>
         /// <param name="length">length of bytes to read (OPTIONAL)</param>
         /// <returns></returns>
-        public string readString(string code, string file = "", int length = 255)
+        public string readString(string code, bool zeroTerminated = false, Encoding encoding = null, string file = "", int length = 255)
         {
+            if (encoding == null)
+                encoding = Encoding.Default;
             byte[] memoryNormal = new byte[length];
             UIntPtr theCode;
             theCode = getCode(code, file);
             if (ReadProcessMemory(pHandle, theCode, memoryNormal, (UIntPtr)length, IntPtr.Zero))
-                return Encoding.UTF8.GetString(memoryNormal).Split('\0')[0];
+                return (zeroTerminated) ? encoding.GetString(memoryNormal).Split('\0')[0] : encoding.GetString(memoryNormal);
             else
                 return "";
         }

--- a/Memory/Class1.cs
+++ b/Memory/Class1.cs
@@ -568,12 +568,12 @@ namespace Memory
         /// Read a string value from an address.
         /// </summary>
         /// <param name="code">address, module + pointer + offset, module + offset OR label in .ini file.</param>
+	/// <param name="length">length of bytes to read (OPTIONAL)</param>
         /// <param name="encoding">the encoding that will be used for GetString.</param>
         /// <param name="zeroTerminated">determines if the string will be splited at null char.</param>
-        /// <param name="file">path and name of ini file. (OPTIONAL)</param>
-        /// <param name="length">length of bytes to read (OPTIONAL)</param>
+        /// <param name="file">path and name of ini file. (OPTIONAL)</param>        
         /// <returns></returns>
-        public string readString(string code, bool zeroTerminated = false, Encoding encoding = null, string file = "", int length = 255)
+        public string readString(string code, int length = 255, bool zeroTerminated = false, Encoding encoding = null, string file = "")
         {
             if (encoding == null)
                 encoding = Encoding.Default;


### PR DESCRIPTION
### About unnecessary use of Regex import:

there's a 
```cs
using System.Text.RegularExpressions;
```
doing nothing here.

### About fixing ReadString:

```cs
/// <summary>
/// Read a string value from an address.
/// </summary>
/// <param name="code">address, module + pointer + offset, module + offset OR label in .ini file.</param>
/// <param name="encoding">the encoding that will be used for GetString.</param>
/// <param name="zeroTerminated">determines if the string will be splited at null char.</param>
/// <param name="file">path and name of ini file. (OPTIONAL)</param>
/// <param name="length">length of bytes to read (OPTIONAL)</param>
/// <returns></returns>
public string readString(string code, bool zeroTerminated = false, Encoding encoding = null, string file = "", int length = 255)
        {
            if (encoding == null)
                encoding = Encoding.Default;
            byte[] memoryNormal = new byte[length];
            UIntPtr theCode;
            theCode = getCode(code, file);
            if (ReadProcessMemory(pHandle, theCode, memoryNormal, (UIntPtr)length, IntPtr.Zero))
                return (zeroTerminated) ? encoding.GetString(memoryNormal).Split('\0')[0] : encoding.GetString(memoryNormal);
            else
                return "";
        }
```

### About optional '?' instead of '??' on AoB Scan:

Issue https://github.com/erfg12/memory.dll/issues/32

Let's give the chance of using '?' instead of '??' on AoB Scan

```cs
if (ba == "??" || ba.Length == 1 && ba == "?")
```
instead of
```cs
if (ba == "??")
```

![](https://i.imgur.com/isYsilg.png)

Why not? :D 

