### PR TITLE
Fixed bug causing string not to overwrite entirely

### DIFF
--- a/Memory/memory.cs
+++ b/Memory/memory.cs
@@ -996,12 +996,11 @@ namespace Memory
             }
             else if (type.ToLower() == "string")
             {
-                memory = new byte[write.Length];
                 if (stringEncoding == null)
                     memory = System.Text.Encoding.UTF8.GetBytes(write);
                 else
                     memory = stringEncoding.GetBytes(write);
-                size = write.Length;
+                size = memory.Length;
             }
             //Debug.Write("DEBUG: Writing bytes [TYPE:" + type + " ADDR:" + theCode + "] " + String.Join(",", memory) + Environment.NewLine);
             return WriteProcessMemory(pHandle, theCode, memory, (UIntPtr)size, IntPtr.Zero);


### PR DESCRIPTION
Since the amount of actual bytes being overwritten will differ from just the string length, you would need "extra space".