### PR TITLE
Supposedly fixed an issue with VirtualAllocEx

### DIFF
--- a/Memory/memory.cs
+++ b/Memory/memory.cs
@@ -1449,7 +1449,7 @@ namespace Memory
         /// <remarks>Please ensure that you use the proper replaceCount
         /// if you replace halfway in an instruction you may cause bad things</remarks>
         /// <returns>UIntPtr to created code cave for use for later deallocation</returns>
-        public UIntPtr CreateCodeCave(string code, byte[] newBytes, int replaceCount, int allocationSize = 0x1000, string file = "")
+        public UIntPtr CreateCodeCave(string code, byte[] newBytes, int replaceCount, int size = 0x1000, string file = "")
         {
             if (replaceCount < 5)
                 return UIntPtr.Zero; // returning UIntPtr.Zero instead of throwing an exception
@@ -1466,8 +1466,8 @@ namespace Memory
 
             for(var i = 0; i < 10 && caveAddress == UIntPtr.Zero; i++)
             {
-                caveAddress = VirtualAllocEx(pHandle, FindFreeBlockForRegion(prefered, (uint)allocationSize),
-                                             (uint)allocationSize, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+                caveAddress = VirtualAllocEx(pHandle, FindFreeBlockForRegion(prefered, (uint)size),
+                                             (uint)size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
 
                 if (caveAddress == UIntPtr.Zero)
                     prefered = UIntPtr.Add(prefered, 0x10000);
@@ -1475,7 +1475,7 @@ namespace Memory
 
             // Failed to allocate memory around the address we wanted let windows handle it and hope for the best?
             if (caveAddress == UIntPtr.Zero)
-                caveAddress = VirtualAllocEx(pHandle, UIntPtr.Zero, (uint)allocationSize, MEM_COMMIT | MEM_RESERVE,
+                caveAddress = VirtualAllocEx(pHandle, UIntPtr.Zero, (uint)size, MEM_COMMIT | MEM_RESERVE,
                                              PAGE_EXECUTE_READWRITE);
 
             int nopsNeeded = replaceCount > 5 ? replaceCount - 5 : 0;

--- a/Memory/memory.cs
+++ b/Memory/memory.cs
@@ -1444,12 +1444,12 @@ namespace Memory
         /// <param name="code">Address to create the trampoline</param>
         /// <param name="newBytes">The opcodes to write in the code cave</param>
         /// <param name="replaceCount">The number of bytes being replaced</param>
-        /// <param name="size">size of the allocated region</param>
+        /// <param name="allocationSize">size of the allocated region</param>
         /// <param name="file">ini file to look in</param>
         /// <remarks>Please ensure that you use the proper replaceCount
         /// if you replace halfway in an instruction you may cause bad things</remarks>
         /// <returns>UIntPtr to created code cave for use for later deallocation</returns>
-        public UIntPtr CreateCodeCave(string code, byte[] newBytes, int replaceCount, int size = 0x10000, string file = "")
+        public UIntPtr CreateCodeCave(string code, byte[] newBytes, int replaceCount, int allocationSize = 0x1000, string file = "")
         {
             if (replaceCount < 5)
                 return UIntPtr.Zero; // returning UIntPtr.Zero instead of throwing an exception
@@ -1466,8 +1466,8 @@ namespace Memory
 
             for(var i = 0; i < 10 && caveAddress == UIntPtr.Zero; i++)
             {
-                caveAddress = VirtualAllocEx(pHandle, FindFreeBlockForRegion(prefered, (uint)newBytes.Length),
-                                             (uint)size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+                caveAddress = VirtualAllocEx(pHandle, FindFreeBlockForRegion(prefered, (uint)allocationSize),
+                                             (uint)allocationSize, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
 
                 if (caveAddress == UIntPtr.Zero)
                     prefered = UIntPtr.Add(prefered, 0x10000);
@@ -1475,7 +1475,7 @@ namespace Memory
 
             // Failed to allocate memory around the address we wanted let windows handle it and hope for the best?
             if (caveAddress == UIntPtr.Zero)
-                caveAddress = VirtualAllocEx(pHandle, UIntPtr.Zero, (uint)size, MEM_COMMIT | MEM_RESERVE,
+                caveAddress = VirtualAllocEx(pHandle, UIntPtr.Zero, (uint)allocationSize, MEM_COMMIT | MEM_RESERVE,
                                              PAGE_EXECUTE_READWRITE);
 
             int nopsNeeded = replaceCount > 5 ? replaceCount - 5 : 0;

--- a/Memory/memory.cs
+++ b/Memory/memory.cs
@@ -1444,7 +1444,7 @@ namespace Memory
         /// <param name="code">Address to create the trampoline</param>
         /// <param name="newBytes">The opcodes to write in the code cave</param>
         /// <param name="replaceCount">The number of bytes being replaced</param>
-        /// <param name="allocationSize">size of the allocated region</param>
+        /// <param name="size">size of the allocated region</param>
         /// <param name="file">ini file to look in</param>
         /// <remarks>Please ensure that you use the proper replaceCount
         /// if you replace halfway in an instruction you may cause bad things</remarks>


### PR DESCRIPTION
If I only want 10 bytes to write(pass 10 as newBytes argument), it will find free block with only 10 bytes but will reserve 10000(assuming we don't pass size argument at all), which can potentially cause undefined behavior.

On a VirtualAllocExFix branch it will try to find free region in memory that is equal to the size that it will allocate.

Cchanged default size to 1000 as hollow recommended on Discord "If you do change the size remove one 0 from the default size would be my recommendation as that would be 4KB which tends to be the minimum page size".

Changed name from size to allocationSize to be more descriptive and closer to other descriptive local variables used in a function such as caveAddress(instead of just address) and caveBytes(instead of just bytes)