### PR TITLE
Add unmanaged generic support to ReadMemory/WriteMemory

### DIFF
--- a/Memory/Memory.csproj
+++ b/Memory/Memory.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Memory.dll.$(Platform)</PackageId>
     <PackageProjectUrl>https://erfg12.github.io/memory.dll</PackageProjectUrl>

--- a/Memory/Methods/Read.cs
+++ b/Memory/Methods/Read.cs
@@ -384,25 +384,22 @@ namespace Memory
                 return "";
         }
 
-        public T ReadMemory<T>(string address, string file = "")
+        public unsafe T ReadMemory<T>(string address, string file = "")
         {
-            unsafe
+            var T_type = typeof(T);
+            var T_size = sizeof(T);
+
+            var bytes = ReadBytes(address, T_size);
+
+            if (bytes == null || bytes.Length < T_size)
             {
-                var T_type = typeof(T);
-                var T_size = sizeof(T);
-
-                var bytes = ReadBytes(address, T_size);
-
-                if (bytes == null || bytes.Length < T_size)
-                {
-                    return default;
-                }
+                return default;
+            }
 
 
-                fixed (byte* ptr = bytes)
-                {
-                    return *(T*)ptr;
-                }
+            fixed (byte* ptr = bytes)
+            {
+                return *(T*)ptr;
             }
         }
 

--- a/Memory/Methods/Read.cs
+++ b/Memory/Methods/Read.cs
@@ -386,39 +386,24 @@ namespace Memory
 
         public T ReadMemory<T>(string address, string file = "")
         {
-            object ReadOutput = null;
-
-            switch (Type.GetTypeCode(typeof(T)))
+            unsafe
             {
-                case TypeCode.String:
-                    ReadOutput = ReadString(address, file);
-                    break;
-                case TypeCode.Int32:
-                    ReadOutput = ReadInt(address, file);
-                    break;
-                case TypeCode.Int64:
-                    ReadOutput = ReadLong(address, file);
-                    break;
-                case TypeCode.Byte:
-                    ReadOutput = ReadByte(address, file);
-                    break;
-                case TypeCode.Double:
-                    ReadOutput = ReadDouble(address, file);
-                    break;
-                case TypeCode.Decimal:
-                    ReadOutput = ReadFloat(address, file);
-                    break;
-                case TypeCode.UInt32:
-                    ReadOutput = ReadUInt(address, file);
-                    break;
-                default:
-                    break;
-            }
+                var T_type = typeof(T);
+                var T_size = sizeof(T);
 
-            if (ReadOutput != null)
-                return (T)Convert.ChangeType(ReadOutput, typeof(T));
-            else
-                return default(T);
+                var bytes = ReadBytes(address, T_size);
+
+                if (bytes == null || bytes.Length < T_size)
+                {
+                    return default;
+                }
+
+
+                fixed (byte* ptr = bytes)
+                {
+                    return *(T*)ptr;
+                }
+            }
         }
 
         ConcurrentDictionary<string, CancellationTokenSource> ReadTokenSrcs = new ConcurrentDictionary<string, CancellationTokenSource>();

--- a/Memory/Methods/Write.cs
+++ b/Memory/Methods/Write.cs
@@ -20,7 +20,7 @@ namespace Memory
         /// <param name="type">byte, 2bytes, bytes, float, int, string, double or long.</param>
         /// <param name="value">Value to freeze</param>
         /// <param name="file">ini file to read address from (OPTIONAL)</param>
-        public bool FreezeValue(string address, string type, string value, string file = "")
+        public bool FreezeValue<T>(string address, T value, string file = "") where T : unmanaged
         {
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -38,7 +38,8 @@ namespace Memory
                     return false;
                 }
             }
-            else {
+            else
+            {
                 Debug.WriteLine("Adding Freezing Address " + address + " Value " + value);
             }
 
@@ -48,7 +49,7 @@ namespace Memory
             {
                 while (!cts.Token.IsCancellationRequested)
                 {
-                    WriteMemory(address, type, value, file);
+                    WriteMemory(address, value, file);
                     Thread.Sleep(25);
                 }
             },
@@ -87,10 +88,16 @@ namespace Memory
         ///<param name="file">path and name of .ini file (OPTIONAL)</param>
         ///<param name="stringEncoding">System.Text.Encoding.UTF8 (DEFAULT). Other options: ascii, unicode, utf32, utf7</param>
         ///<param name="RemoveWriteProtection">If building a trainer on an emulator (Ex: RPCS3) you'll want to set this to false</param>
-        public bool WriteMemory(string code, string type, string write, string file = "", System.Text.Encoding stringEncoding = null, bool RemoveWriteProtection = true)
+        public unsafe bool WriteMemory<T>(string code, T write, string file = "", System.Text.Encoding stringEncoding = null, bool RemoveWriteProtection = true) where T : unmanaged
         {
-            byte[] memory = new byte[4];
-            int size = 4;
+
+            var size = sizeof(T);
+            var memory = new byte[size];
+
+            fixed (byte* ptr = memory)
+            {
+                *(T*)ptr = write;
+            }
 
             UIntPtr theCode;
             theCode = GetCode(code, file);
@@ -98,89 +105,7 @@ namespace Memory
             if (theCode == null || theCode == UIntPtr.Zero || theCode.ToUInt64() < 0x10000)
                 return false;
 
-            if (type.ToLower() == "float")
-            {
-                if (float.TryParse(write, out float floatValue))
-                {
-                    write = Convert.ToString(floatValue);
-                    memory = BitConverter.GetBytes(Convert.ToSingle(write));
-                    size = 4;
-                }
-                else
-                    Debug.WriteLine($"ERROR: Failed to convert {floatValue} to float!");
-            }
-            else if (type.ToLower() == "int")
-            {
-                memory = BitConverter.GetBytes(Convert.ToInt32(write));
-                size = 4;
-            }
-            else if (type.ToLower() == "byte")
-            {
-                memory = new byte[1];
-                memory[0] = Convert.ToByte(write, 16);
-                size = 1;
-            }
-            else if (type.ToLower() == "2bytes")
-            {
-                memory = new byte[2];
-                memory[0] = (byte)(Convert.ToInt32(write) % 256);
-                memory[1] = (byte)(Convert.ToInt32(write) / 256);
-                size = 2;
-            }
-            else if (type.ToLower() == "bytes")
-            {
-                if (write.Contains(",") || write.Contains(" ")) //check if it's a proper array
-                {
-                    string[] stringBytes;
-                    if (write.Contains(","))
-                        stringBytes = write.Split(',');
-                    else
-                        stringBytes = write.Split(' ');
-                    //Debug.WriteLine("write:" + write + " stringBytes:" + stringBytes);
-
-                    int c = stringBytes.Count();
-                    memory = new byte[c];
-                    for (int i = 0; i < c; i++)
-                    {
-                        memory[i] = Convert.ToByte(stringBytes[i], 16);
-                    }
-                    size = stringBytes.Count();
-                }
-                else //wasnt array, only 1 byte
-                {
-                    memory = new byte[1];
-                    memory[0] = Convert.ToByte(write, 16);
-                    size = 1;
-                }
-            }
-            else if (type.ToLower() == "double")
-            {
-                memory = BitConverter.GetBytes(Convert.ToDouble(write));
-                size = 8;
-            }
-            else if (type.ToLower() == "long")
-            {
-                memory = BitConverter.GetBytes(Convert.ToInt64(write));
-                size = 8;
-            }
-            else if (type.ToLower() == "string")
-            {
-                if (stringEncoding == null)
-                    memory = System.Text.Encoding.UTF8.GetBytes(write);
-                else
-                    memory = stringEncoding.GetBytes(write);
-                size = memory.Length;
-            }
-
-            //Debug.Write("DEBUG: Writing bytes [TYPE:" + type + " ADDR:" + theCode + "] " + String.Join(",", memory) + Environment.NewLine);
-            MemoryProtection OldMemProt = 0x00;
-            bool WriteProcMem = false;
-            //if (RemoveWriteProtection)
-            //    ChangeProtection(code, MemoryProtection.ExecuteReadWrite, out OldMemProt, file); // change protection
-            WriteProcMem = WriteProcessMemory(mProc.Handle, theCode, memory, (UIntPtr)size, IntPtr.Zero);
-            //if (RemoveWriteProtection)
-            //    ChangeProtection(code, OldMemProt, out _, file); // restore
-            return WriteProcMem;
+            return WriteProcessMemory(mProc.Handle, theCode, memory, (UIntPtr)size, IntPtr.Zero);
         }
 
         /// <summary>

--- a/Memory/Methods/Write.cs
+++ b/Memory/Methods/Write.cs
@@ -20,7 +20,7 @@ namespace Memory
         /// <param name="type">byte, 2bytes, bytes, float, int, string, double or long.</param>
         /// <param name="value">Value to freeze</param>
         /// <param name="file">ini file to read address from (OPTIONAL)</param>
-        public bool FreezeValue(string address, string type, string value, string file = "")
+        public bool FreezeValue<T>(string address, T value, string file = "") where T : unmanaged
         {
             CancellationTokenSource cts = new CancellationTokenSource();
 
@@ -38,7 +38,8 @@ namespace Memory
                     return false;
                 }
             }
-            else {
+            else
+            {
                 Debug.WriteLine("Adding Freezing Address " + address + " Value " + value);
             }
 
@@ -48,7 +49,7 @@ namespace Memory
             {
                 while (!cts.Token.IsCancellationRequested)
                 {
-                    WriteMemory(address, type, value, file);
+                    WriteMemory(address, value, file);
                     Thread.Sleep(25);
                 }
             },
@@ -87,10 +88,16 @@ namespace Memory
         ///<param name="file">path and name of .ini file (OPTIONAL)</param>
         ///<param name="stringEncoding">System.Text.Encoding.UTF8 (DEFAULT). Other options: ascii, unicode, utf32, utf7</param>
         ///<param name="RemoveWriteProtection">If building a trainer on an emulator (Ex: RPCS3) you'll want to set this to false</param>
-        public bool WriteMemory(string code, string type, string write, string file = "", System.Text.Encoding stringEncoding = null, bool RemoveWriteProtection = true)
+        public unsafe bool WriteMemory<T>(string code, T write, string file = "", System.Text.Encoding stringEncoding = null, bool RemoveWriteProtection = true) where T : unmanaged
         {
-            byte[] memory = new byte[4];
-            int size = 4;
+
+            var size = sizeof(T);
+            var memory = new byte[size];
+
+            fixed (byte* ptr = memory)
+            {
+                *(T*)ptr = write;
+            }
 
             UIntPtr theCode;
             theCode = GetCode(code, file);
@@ -98,88 +105,10 @@ namespace Memory
             if (theCode == null || theCode == UIntPtr.Zero || theCode.ToUInt64() < 0x10000)
                 return false;
 
-            if (type.ToLower() == "float")
-            {
-                if (float.TryParse(write, out float floatValue))
-                {
-                    write = Convert.ToString(floatValue);
-                    memory = BitConverter.GetBytes(Convert.ToSingle(write));
-                    size = 4;
-                }
-                else
-                    Debug.WriteLine($"ERROR: Failed to convert {floatValue} to float!");
-            }
-            else if (type.ToLower() == "int")
-            {
-                memory = BitConverter.GetBytes(Convert.ToInt32(write));
-                size = 4;
-            }
-            else if (type.ToLower() == "byte")
-            {
-                memory = new byte[1];
-                memory[0] = Convert.ToByte(write, 16);
-                size = 1;
-            }
-            else if (type.ToLower() == "2bytes")
-            {
-                memory = new byte[2];
-                memory[0] = (byte)(Convert.ToInt32(write) % 256);
-                memory[1] = (byte)(Convert.ToInt32(write) / 256);
-                size = 2;
-            }
-            else if (type.ToLower() == "bytes")
-            {
-                if (write.Contains(",") || write.Contains(" ")) //check if it's a proper array
-                {
-                    string[] stringBytes;
-                    if (write.Contains(","))
-                        stringBytes = write.Split(',');
-                    else
-                        stringBytes = write.Split(' ');
-                    //Debug.WriteLine("write:" + write + " stringBytes:" + stringBytes);
-
-                    int c = stringBytes.Count();
-                    memory = new byte[c];
-                    for (int i = 0; i < c; i++)
-                    {
-                        memory[i] = Convert.ToByte(stringBytes[i], 16);
-                    }
-                    size = stringBytes.Count();
-                }
-                else //wasnt array, only 1 byte
-                {
-                    memory = new byte[1];
-                    memory[0] = Convert.ToByte(write, 16);
-                    size = 1;
-                }
-            }
-            else if (type.ToLower() == "double")
-            {
-                memory = BitConverter.GetBytes(Convert.ToDouble(write));
-                size = 8;
-            }
-            else if (type.ToLower() == "long")
-            {
-                memory = BitConverter.GetBytes(Convert.ToInt64(write));
-                size = 8;
-            }
-            else if (type.ToLower() == "string")
-            {
-                if (stringEncoding == null)
-                    memory = System.Text.Encoding.UTF8.GetBytes(write);
-                else
-                    memory = stringEncoding.GetBytes(write);
-                size = memory.Length;
-            }
-
-            //Debug.Write("DEBUG: Writing bytes [TYPE:" + type + " ADDR:" + theCode + "] " + String.Join(",", memory) + Environment.NewLine);
-            MemoryProtection OldMemProt = 0x00;
             bool WriteProcMem = false;
-            //if (RemoveWriteProtection)
-            //    ChangeProtection(code, MemoryProtection.ExecuteReadWrite, out OldMemProt, file); // change protection
+
             WriteProcMem = WriteProcessMemory(mProc.Handle, theCode, memory, (UIntPtr)size, IntPtr.Zero);
-            //if (RemoveWriteProtection)
-            //    ChangeProtection(code, OldMemProt, out _, file); // restore
+
             return WriteProcMem;
         }
 


### PR DESCRIPTION
## Summary
Added generic type support for memory read/write operations using `unsafe` and `unmanaged` constraints.

## Technical Details
- Uses `typeof()`/`sizeof(T)` for fast size calculation
- Requires C# 7.3+ for `where T : unmanaged` constraint

## Scope
- Modified: `ReadMemory&lt;T&gt;()`, `WriteMemory&lt;T&gt;()`
